### PR TITLE
Fix null pointer dereference in nvMemoryPool_free

### DIFF
--- a/src/core/pool.c
+++ b/src/core/pool.c
@@ -32,6 +32,8 @@ nvMemoryPool *nvMemoryPool_new(size_t chunk_size, size_t initial_num_chunks) {
 }
 
 void nvMemoryPool_free(nvMemoryPool *pool) {
+    if (!pool) return;
+
     NV_FREE(pool->pool);
     NV_FREE(pool);
 }


### PR DESCRIPTION
## Summary

The `nvMemoryPool_free` function did not check if the `pool` pointer was null before accessing `pool->pool` and freeing the pool structure. This could cause a null pointer dereference crash when the function is called with a null pointer.

## Changes

- Added null check at the beginning of `nvMemoryPool_free` function
- Returns early if pool is null, preventing null pointer dereference

## Testing

The fix follows the same pattern used in other similar functions in the codebase (e.g., `nvArray_free` in `src/core/array.c`).

## Related

Fixes bug #639: Missing null check in nvMemoryPool_free before accessing pool members

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.